### PR TITLE
Handle multi-hop verification and DRY SyncManager

### DIFF
--- a/crates/service/src/jax_state.rs
+++ b/crates/service/src/jax_state.rs
@@ -13,7 +13,7 @@ use crate::database::Database;
 use crate::sync_manager::SyncEvent;
 
 /// Maximum depth to traverse when checking bucket history
-const MAX_HISTORY_DEPTH: usize = 100;
+pub const MAX_HISTORY_DEPTH: usize = 100;
 
 /// State provider for the JAX protocol
 ///


### PR DESCRIPTION
Add multi-hop sync verification, DRY shared logic, and first-time bucket setup

- Implement multi-hop verification via `verify_multi_hop` with `MultiHopOutcome` to safely converge across multiple versions.
- Reuse `MAX_HISTORY_DEPTH` and avoid double-downloads by caching the first manifest during verification.
- Extract `verify_and_apply_update` to share “download → verify → pinset → update link” flow between pull and announce.
- Extract `create_bucket_from_peer` to canonically create a bucket on first announce (derive name from manifest, create DB row, best-effort pin download).
- Remove redundant single-hop double-checks; keep provenance check only where needed.
- Improve logs and error handling; no API changes.