### PR TITLE
fix: use gateway URL for download button instead of localhost API

### DIFF
--- a/crates/app/templates/pages/buckets/viewer.html
+++ b/crates/app/templates/pages/buckets/viewer.html
@@ -590,13 +590,13 @@
         const downloadBtn = document.getElementById('downloadBtn');
         if (downloadBtn) {
             downloadBtn.addEventListener('click', function() {
-                // Build API URL for downloading the file
-                const apiUrl = window.JAX_API_URL || 'http://localhost:3000';
-                let url = `${apiUrl}/api/v0/bucket/cat?bucket_id=${window.JAX_BUCKET_ID}&path=${encodeURIComponent(window.JAX_FILE_PATH)}&download=true`;
+                // Use gateway URL (same as share button)
+                const host = window.location.origin;
+                let url = `${host}/gw/${window.JAX_BUCKET_ID}${window.JAX_FILE_PATH}`;
 
                 // Add at_hash if viewing history
                 if (window.JAX_AT_HASH) {
-                    url += `&at=${window.JAX_AT_HASH}`;
+                    url += `?at=${window.JAX_AT_HASH}`;
                 }
 
                 // Trigger download by navigating to URL


### PR DESCRIPTION
## Summary
- Fixed download button to use gateway URL instead of localhost API
- This ensures downloads work on remote read-only nodes that don't expose the API over the internet
- Now uses the same URL pattern as the share button for consistency

## Changes
- Replace `window.JAX_API_URL` (localhost) with `window.location.origin` + gateway path
- Use `/gw/{bucket_id}{file_path}` format (matching share button behavior)
- Fix query string for `at` parameter (use `?` instead of `&` as first parameter)

## Test plan
- [ ] Test download button on local node
- [ ] Test download button on remote read-only node
- [ ] Verify historical version downloads work with `at` parameter
- [ ] Confirm gateway URL matches share button URL format

🤖 Generated with [Claude Code](https://claude.com/claude-code)