### PR TITLE
docs: update issue tickets to match --gateway flag implementation

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -71,6 +71,18 @@ For each issue file, check if this branch addresses or impacts it:
 - Should new issues be created for follow-up work?
 - Are there epic tickets that need progress updates?
 
+**IMPORTANT: Downstream Impact Analysis**
+
+When a ticket's implementation differs from its original spec:
+1. **Update the completed ticket** with actual implementation details (CLI flags, file paths, etc.)
+2. **Check downstream tickets** that depend on this work
+3. **Update downstream tickets** if they reference outdated assumptions (e.g., old CLI flag names, removed files)
+4. **Add a "Downstream Impact" section** to the completed ticket noting what changed
+
+Example: If ticket 0 planned `--gateway-only` but implemented `--gateway`, update:
+- Ticket 0's docs to show `--gateway`
+- Any downstream tickets (1, 2, etc.) that reference `--gateway-only`
+
 ## Output Format
 
 Provide a structured review report:
@@ -95,6 +107,7 @@ Provide a structured review report:
 ## Related Issues
 - Issues addressed by this branch: (list or "None")
 - Issues needing status update: (list or "None")
+- Downstream tickets impacted: (list tickets that reference changed assumptions, or "None")
 - Suggested follow-up issues: (list or "None")
 
 ## Summary

--- a/issues/gateway-tauri-split/0-gateway-subcommand.md
+++ b/issues/gateway-tauri-split/0-gateway-subcommand.md
@@ -2,11 +2,11 @@
 
 **Status:** Done
 **Track:** Gateway
+**Branch:** `alex/gateway-subcommand`
 
 ## Completion Notes
 
-We did not make this a subcommand, and instead implemented
- this as a new flag
+We did not make this a subcommand, and instead implemented this as a new flag.
 
 ## Objective
 
@@ -16,13 +16,32 @@ Add gateway-only mode to the daemon that runs a minimal gateway service: P2P pee
 
 Instead of a separate `jax gw` subcommand, the gateway is integrated into the daemon command:
 
-- `jax daemon --gateway-only` - Run only the gateway server (no HTML UI, no API)
-- `jax daemon --gateway --gateway-url <url>` - Run full daemon + gateway on separate port
+- `jax daemon --gateway` - Run only the gateway server (no App UI, no API)
+- `jax daemon --with-gateway` - Run full daemon + gateway on separate ports
+- `jax daemon --gateway-port <port>` - Override gateway port (implies `--with-gateway`)
 
 This approach:
-- Reuses the existing daemon infrastructure
+- Reuses the existing daemon infrastructure (single `spawn_service` function)
 - Avoids code duplication
 - Provides consistent configuration via `config.toml`
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--gateway` | Gateway-only mode (no App server) |
+| `--with-gateway` | Run App + Gateway together |
+| `--gateway-port <port>` | Override gateway port |
+| `--gateway-url <url>` | External gateway URL for share links |
+| `--api-url <url>` | API URL for HTML UI |
+
+### Architecture
+
+The server spawning was consolidated into a single `spawn_service` function that conditionally starts:
+- App server (Askama UI + REST API) on `app_port`
+- Gateway server (read-only content serving) on `gateway_port`
+
+Both servers share the same `ServiceState` (peer, database, etc.).
 
 ## Files Created
 
@@ -36,17 +55,20 @@ This approach:
 
 | File | Changes |
 |------|---------|
-| `crates/app/src/ops/daemon.rs` | Add `--gateway-only`, `--gateway`, `--gateway-url` flags |
-| `crates/app/src/daemon/process/mod.rs` | Add `spawn_gateway_service` function |
-| `crates/app/src/daemon/http_server/html/gateway/mod.rs` | Add HTML templates and content negotiation |
+| `crates/app/src/ops/daemon.rs` | Add `--gateway`, `--with-gateway`, `--gateway-port`, `--gateway-url` flags |
+| `crates/app/src/daemon/mod.rs` | Export `ServiceConfig`, `spawn_service` |
+| `crates/app/src/daemon/config.rs` | Add `api_url`, `gateway_url` fields |
+| `crates/app/src/daemon/process.rs` | Consolidated server spawning logic |
+| `crates/app/src/daemon/http_server/html/gateway/mod.rs` | Gateway handlers with content negotiation |
 
 ## Acceptance Criteria
 
-- [x] `jax daemon --gateway-only` starts gateway server
+- [x] `jax daemon --gateway` starts gateway-only server
 - [x] P2P peer syncs as mirror role
 - [x] `/gw/:bucket_id/*` serves published content with HTML UI
 - [x] `Accept: application/json` header returns JSON for programmatic access
 - [x] `?download=true` returns raw file download
+- [x] `?deep=true` returns recursive directory listing
 - [x] No Askama UI routes available in gateway-only mode
 - [x] No REST API routes available in gateway-only mode
 - [x] `cargo test` passes
@@ -56,7 +78,7 @@ This approach:
 
 ```bash
 # Start gateway-only
-cargo run -- --config-path ./data/node3 daemon --gateway-only
+cargo run -- --config-path ./data/node3 daemon --gateway
 
 # In another terminal, start full daemon
 cargo run -- --config-path ./data/node1 daemon
@@ -67,6 +89,9 @@ open http://localhost:9092/gw/<bucket-id>
 # Verify JSON API
 curl -H "Accept: application/json" http://localhost:9092/gw/<bucket-id>
 
+# Verify deep listing
+curl -H "Accept: application/json" "http://localhost:9092/gw/<bucket-id>?deep=true"
+
 # Verify raw download
 curl "http://localhost:9092/gw/<bucket-id>/file.txt?download=true"
 
@@ -76,3 +101,7 @@ curl http://localhost:9092/buckets  # Should 404
 # Verify identity endpoint
 curl http://localhost:9092/_status/identity
 ```
+
+## Downstream Impact
+
+**Ticket 1 (SQLite blob store):** CLI examples updated to use `--gateway` instead of `--gateway-only`

--- a/issues/gateway-tauri-split/1-sqlite-blobstore.md
+++ b/issues/gateway-tauri-split/1-sqlite-blobstore.md
@@ -37,7 +37,7 @@ Integrate SQLite + Object Storage blob backend into gateway for cloud-native dep
 
 - [ ] `crates/blobs-store` compiles independently
 - [ ] Trait bridge implements iroh-blobs store traits
-- [ ] `jax daemon --gateway-only --blob-store s3 --s3-endpoint ...` works
+- [ ] `jax daemon --gateway --blob-store s3 --s3-endpoint ...` works
 - [ ] SQLite metadata can be rebuilt from object storage
 - [ ] `cargo test` passes
 - [ ] `cargo clippy` has no warnings
@@ -49,7 +49,7 @@ Integrate SQLite + Object Storage blob backend into gateway for cloud-native dep
 ./bin/minio.sh start
 
 # Start gateway with S3 config
-cargo run -- daemon --gateway-only --blob-store s3 --s3-endpoint http://localhost:9000 --s3-bucket jax-blobs
+cargo run -- daemon --gateway --blob-store s3 --s3-endpoint http://localhost:9000 --s3-bucket jax-blobs
 
 # Verify blobs stored in MinIO
 mc ls minio/jax-blobs

--- a/issues/gateway-tauri-split/index.md
+++ b/issues/gateway-tauri-split/index.md
@@ -4,21 +4,27 @@
 
 The current `jax daemon` combines full local client functionality (Askama UI, REST API, P2P sync) with gateway serving. This limits deployment flexibility for edge/CDN use cases.
 
-We added a `--gateway-only` mode to the daemon that runs a minimal gateway service: P2P peer (mirror role) + gateway content serving + SQLite/Object Storage backend.
+We added a `--gateway` mode to the daemon that runs a minimal gateway service: P2P peer (mirror role) + gateway content serving. A future ticket will add SQLite/Object Storage backend support.
 
 ## Architecture
 
 ```
-jax daemon (full local client)
+jax daemon (full local client - default)
 ├── P2P peer (owner/mirror roles)
 ├── Askama web UI
 ├── REST API
-└── Gateway handler (optional, via --gateway flag)
+└── No gateway
 
-jax daemon --gateway-only (gateway mode)
+jax daemon --with-gateway (app + gateway)
+├── P2P peer (owner/mirror roles)
+├── Askama web UI (port 8080)
+├── REST API
+└── Gateway handler (port 9092)
+
+jax daemon --gateway (gateway-only mode)
 ├── P2P peer (mirror role)
 ├── Gateway handler with read-only HTML file explorer
-└── SQLite + Object Storage blob backend
+└── (Future: SQLite + Object Storage blob backend)
 ```
 
 ## Tickets
@@ -35,7 +41,7 @@ jax daemon --gateway-only (gateway mode)
 ## Execution Order
 
 **Stage 1 (Foundation):**
-- Ticket 0: Gateway subcommand (`jax daemon --gateway-only`) - **Done**
+- Ticket 0: Gateway subcommand (`jax daemon --gateway`) - **Done**
 
 **Stage 2 (Parallel Tracks):**
 


### PR DESCRIPTION
## Summary

- Update issue tickets to use actual `--gateway` flag (not `--gateway-only`)
- Update downstream ticket 1 with correct CLI examples
- Add downstream impact guidance to review command

## Changes

### Issue Tickets
- `0-gateway-subcommand.md` - Updated with actual CLI flags, architecture details, downstream impact section
- `1-sqlite-blobstore.md` - Fixed examples to use `--gateway`
- `index.md` - Updated architecture diagram showing all three modes

### Review Command
- Added "Downstream Impact Analysis" guidance
- Added "Downstream tickets impacted" to output format

## Test plan

- [x] Documentation changes only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)