### PR TITLE
feat: add manifest signature support for authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
+ "serde",
  "signature 2.2.0",
 ]
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -37,7 +37,7 @@ aes-gcm = "0.10"
 chacha20poly1305 = { version = "0.10", features = ["stream"] }
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 curve25519-dalek = "4.0"
-ed25519-dalek = "2.2.0"
+ed25519-dalek = { version = "2.2.0", features = ["serde"] }
 blake3 = "1.5"
 
 # linked data

--- a/crates/common/src/crypto/mod.rs
+++ b/crates/common/src/crypto/mod.rs
@@ -36,6 +36,7 @@ mod keys;
 mod secret;
 mod secret_share;
 
+pub use ed25519_dalek::Signature;
 pub use keys::{PublicKey, SecretKey};
 pub use secret::{Secret, SecretError, BLAKE3_HASH_SIZE};
 pub use secret_share::{SecretShare, SecretShareError};

--- a/crates/common/src/mount/mod.rs
+++ b/crates/common/src/mount/mod.rs
@@ -50,7 +50,7 @@ mod path_ops;
 mod pins;
 mod principal;
 
-pub use manifest::{Manifest, Share, Shares};
+pub use manifest::{Manifest, ManifestError, Share, Shares};
 pub use mount_inner::{Mount, MountError};
 pub use node::{Node, NodeError, NodeLink};
 pub use path_ops::{OpId, OpType, PathOpLog, PathOperation};

--- a/issues/signed-manifest-authorization/index.md
+++ b/issues/signed-manifest-authorization/index.md
@@ -46,7 +46,7 @@ Proposed (secure):
 
 | # | Ticket | Status | Description |
 |---|--------|--------|-------------|
-| 0 | [Manifest signature](./0-manifest-signature.md) | Planned | Add author/signature fields to Manifest |
+| 0 | [Manifest signature](./0-manifest-signature.md) | Done | Add author/signature fields to Manifest |
 | 1 | [Sync validation](./1-sync-validation.md) | Planned | Validate signature and author during sync |
 | 2 | [Role enforcement](./2-role-enforcement.md) | Planned | Reject updates from non-owners |
 


### PR DESCRIPTION
## Summary
- Add `author` and `signature` fields to `Manifest` for cryptographic proof of authorship
- Implement signing/verification methods for manifests
- Automatically sign manifests in `Mount::init()` and `Mount::save()`

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (65 tests including new signing tests)
- [x] `cargo clippy` has no warnings
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)